### PR TITLE
Fix input trimming and translation typo

### DIFF
--- a/kontakt.html
+++ b/kontakt.html
@@ -103,10 +103,10 @@
       <h2>Kontakt/Contact/Contacto</h2>
 
       <form action="senden.php" method="POST" onsubmit="return validateForm();">
-        <label for="betreff">Betreff/Subject/Objet/Asunzo</label>
+        <label for="betreff">Betreff/Subject/Objet/Asunto</label>
         <select id="betreff" name="betreff" required>
           <option value="">
-            Bitte wählen/Please select/euillez choisir/Por favor, seleccione
+            Bitte wählen/Please select/Veuillez choisir/Por favor, seleccione
           </option>
           <option value="problem">Ich habe ein Problem</option>
           <option value="vorschlag">Ich möchte etwas vorschlagen</option>

--- a/senden.php
+++ b/senden.php
@@ -4,11 +4,11 @@ $empfaenger = "elmar@pacemind.io"; // <-- Deine echte E-Mail hier eintragen
 $absenderAdresse = "website@pacemind.io"; // Optional, muss auf Mittwald existieren
 
 // Felder auslesen und filtern
-$betreff   = isset($_POST['betreff']) ? strip_tags($_POST['betreff']) : '';
-$vorname   = isset($_POST['vorname']) ? strip_tags($_POST['vorname']) : '';
-$nachname  = isset($_POST['nachname']) ? strip_tags($_POST['nachname']) : '';
-$email     = isset($_POST['email']) ? filter_var($_POST['email'], FILTER_VALIDATE_EMAIL) : '';
-$nachricht = isset($_POST['nachricht']) ? strip_tags($_POST['nachricht']) : '';
+$betreff   = isset($_POST['betreff']) ? strip_tags(trim($_POST['betreff'])) : '';
+$vorname   = isset($_POST['vorname']) ? strip_tags(trim($_POST['vorname'])) : '';
+$nachname  = isset($_POST['nachname']) ? strip_tags(trim($_POST['nachname'])) : '';
+$email     = isset($_POST['email']) ? filter_var(trim($_POST['email']), FILTER_VALIDATE_EMAIL) : '';
+$nachricht = isset($_POST['nachricht']) ? strip_tags(trim($_POST['nachricht'])) : '';
 
 // Validierung
 if (!$email || !$betreff || !$vorname || !$nachname || !$nachricht) {


### PR DESCRIPTION
## Summary
- sanitize form data by trimming whitespace in `senden.php`
- fix Spanish translation of "Asunto" and the French placeholder text in contact form

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68402cad87788330ae5d169826a37f8c